### PR TITLE
Feat: Proper typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.10",
     install_requires=[
-        "AthenaLib>=1.1.0",
+        "AthenaLib>=1.1.0,<2.0.0",
         "AthenaColor>=6.0.1"
     ]
 )

--- a/src/AthenaTwitchBot/data/global_vars.py
+++ b/src/AthenaTwitchBot/data/global_vars.py
@@ -3,10 +3,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from typing import Any
 # Custom Library
 
 # Custom Packages
+from AthenaTwitchBot.models.twitch_bot.bot_server import BotServer
+from AthenaTwitchBot.models.twitch_bot.twitch_bot import TwitchBot
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Bot Server -
@@ -15,5 +16,5 @@ from typing import Any
 # the variables stored here are to be set when the BotServer is created
 #   These variables are used by various functions and classes to call back to
 
-bot_server:Any=None # stands for the BotServer
-bot:Any = None      # stands for the TwitchBot
+bot_server: BotServer | None = None # stands for the BotServer
+bot: TwitchBot | None = None     # stands for the TwitchBot

--- a/src/AthenaTwitchBot/data/twitch_api_scopes.py
+++ b/src/AthenaTwitchBot/data/twitch_api_scopes.py
@@ -3,7 +3,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
+
 import enum
+from collections.abc import Mapping
+from typing import Self
 
 # Custom Library
 
@@ -59,5 +62,5 @@ class TwitchApiScopes(enum.Enum):
     WhispersEdit = "whispers:edit"
 
     @classmethod
-    def string_mapping(cls) -> dict[str:enum.Enum]:
+    def string_mapping(cls) -> Mapping[str, Self]:  # type: ignore [valid-type]
         return {v.value:v for v in cls._member_map_.values()}

--- a/src/AthenaTwitchBot/models/launcher.py
+++ b/src/AthenaTwitchBot/models/launcher.py
@@ -3,8 +3,9 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-import asyncio
 
+import asyncio
+from typing import Any
 # Custom Library
 
 # Custom Packages
@@ -20,37 +21,30 @@ import AthenaTwitchBot.data.global_vars as gbl
 class Launcher:
     _loop:asyncio.AbstractEventLoop
 
-    _api:TwitchAPI=None
-    _bot:TwitchBot=None
+    _api:TwitchAPI | None = None
+    _bot:TwitchBot | None = None
 
     # ------------------------------------------------------------------------------------------------------------------
     # - Properties -
     # ------------------------------------------------------------------------------------------------------------------
     @classmethod
-    @property
-    def api(cls) -> TwitchAPI:
-        if cls._api is None:
-            raise ValueError("The API connector was never started")
-        return cls._api
-
-    @classmethod
-    async def start_API_connector(cls,broadcaster_token:str,broadcaster_client_id:str):
+    async def start_API_connector(cls,broadcaster_token:str,broadcaster_client_id:str) -> None:
         cls._api = TwitchAPI(
             broadcaster_token=broadcaster_token,
             broadcaster_client_id=broadcaster_client_id
         )
         # connect to the API
-        await cls.api.connect()
+        await cls._api.connect()
 
     @classmethod
-    async def start_Bot(cls, bot:TwitchBot,*,sll:bool=True,**kwargs):
-        gbl.bot = cls.bot = bot
+    async def start_Bot(cls, bot:TwitchBot,*,sll:bool=True,**kwargs: Any) -> None:
+        gbl.bot = cls._bot = bot
         gbl.bot_server = BotServer(ssl_enabled=sll, **kwargs)
         await gbl.bot_server.launch()
 
 
     @classmethod
-    async def start_all(cls, bot:TwitchBot,broadcaster_token:str, broadcaster_client_id:str, *,sll:bool=True, **kwargs):
+    async def start_all(cls, bot:TwitchBot,broadcaster_token:str, broadcaster_client_id:str, *,sll:bool=True, **kwargs: Any) -> None:
         await cls.start_API_connector(
             broadcaster_token=broadcaster_token,
             broadcaster_client_id=broadcaster_client_id

--- a/src/AthenaTwitchBot/models/twitch_api/twitch_api_user.py
+++ b/src/AthenaTwitchBot/models/twitch_api/twitch_api_user.py
@@ -4,6 +4,9 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass, field
+from collections.abc import Mapping
+from typing import Any
+from typing import Self
 
 # Custom Library
 
@@ -15,26 +18,24 @@ from AthenaTwitchBot.data.twitch_api_scopes import TwitchApiScopes
 # ----------------------------------------------------------------------------------------------------------------------
 @dataclass(slots=True, kw_only=True)
 class TwitchApiUser:
-    id:str=None
-    login:str=None
-    display_name:str=None
-    type:str=None
-    broadcaster_type:str=None
-    description:str=None
-    profile_image_url:str=None
-    offline_image_url:str=None
-    view_count:int=None
-    email:str=None
-    created_at:str=None
+    id:str | None = None
+    login:str | None = None
+    display_name:str | None = None
+    type:str | None = None
+    broadcaster_type:str | None = None
+    description:str | None = None
+    profile_image_url:str | None = None
+    offline_image_url:str | None = None
+    view_count:int | None = None
+    email:str | None = None
+    created_at:str | None = None
 
-    scopes:set[TwitchApiScopes]=None
+    scopes:set[TwitchApiScopes] | None = None
 
+    # `data` actually should have a type like Mapping[str, str | None]: type checker issue
     @classmethod
-    def new_from_dict(cls, data:dict) -> TwitchApiUser:
-        obj = cls()
-        for k,v in data.items():
-            setattr(obj, k, v)
-        return obj
+    def new_from_dict(cls, data:Mapping[str, Any]) -> Self:  # type: ignore[valid-type]
+        return cls(**data)
 
     def set_scopes(self, data:list[str]) -> TwitchApiUser:
         scopes_string_mapping = TwitchApiScopes.string_mapping()

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_chat_message.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_chat_message.py
@@ -3,6 +3,7 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -10,24 +11,25 @@ from typing import ClassVar
 
 # Custom Packages
 from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import BotMethodCallback
+from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import TBMCCallback
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
 # ----------------------------------------------------------------------------------------------------------------------
 @dataclass(slots=True)
 class BotChatMessage(BotMethodCallback):
-    registered: ClassVar[BotChatMessage] = None
+    registered: ClassVar[BotChatMessage | None] = None
 
     @classmethod
     def register(
             cls,
             *,
             args:bool=False
-    ):
+    ) -> Callable[[TBMCCallback], None]:
         """Registers the function to the class"""
         if cls.registered is not None:
             raise ValueError("Only one First-Time-Chatter command can be allowed at the same time")
-        def decorator(fnc):
+        def decorator(fnc: TBMCCallback) -> None:
             cls.registered = cls(
                 callback=fnc,
                 args=args

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_command.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_command.py
@@ -4,6 +4,8 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass
+from collections.abc import MutableMapping
+from collections.abc import Callable
 from typing import ClassVar
 import datetime
 
@@ -11,6 +13,7 @@ import datetime
 
 # Custom Packages
 from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.rate_limit import BotMethodRateLimit
+from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import TBMCCallback
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
@@ -39,24 +42,20 @@ class BotCommand(BotMethodRateLimit):
     - channel : list of TwitchChannel values which defines on which channels this command should be enabled.
         If left unassigned it will work on all channels the bot is joined on
     """
-    name:str=None
-    subscriber_only:bool=None
-    mod_only:bool=None
+    name:str | None = None
+    subscriber_only:bool=False
+    mod_only:bool=False
 
-    registered:ClassVar[dict[str,BotCommand]]=None
+    registered:ClassVar[MutableMapping[str, BotCommand]]={}
 
     # ------------------------------------------------------------------------------------------------------------------
     @classmethod
     def register(
             cls, name:str,
             *,
-            args:bool=False,subscriber_only:bool=False, mod_only:bool=False, rate_limit:datetime.timedelta=None
-    ):
+            args:bool=False,subscriber_only:bool=False, mod_only:bool=False, rate_limit:datetime.timedelta | None = None
+    ) -> Callable[[TBMCCallback], None]:
         """Registers the function to the class"""
-
-        # make sure the register exists
-        if cls.registered is None:
-            cls.registered = {}
 
         # only allow commands to be used by one level of roles,
         #   and not by multiple at the same time
@@ -71,7 +70,7 @@ class BotCommand(BotMethodRateLimit):
         #   Doesn't behave like a regular decorator because we aren't storing a "wrapper" which handles args and kwargs
         #   Args and kwargs of the function are handled by the handle_chat_message function
         #   It is expected that the function is located within the defined TwitchBot of the application
-        def decorator(fnc):
+        def decorator(fnc: TBMCCallback) -> None:
             cls.registered[name] = cls(
                 name=name,
                 callback=fnc,

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_custom_reward.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_custom_reward.py
@@ -4,12 +4,15 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass
+from collections.abc import Callable
+from collections.abc import MutableMapping
 from typing import ClassVar
 
 # Custom Library
 
 # Custom Packages
 from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import BotMethodCallback
+from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import TBMCCallback
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
@@ -33,20 +36,16 @@ class BotCustomReward(BotMethodCallback):
         The command needs this value to define on which eedeem it should trigger the callback
     - args : Boolean option to allow the remaining chat words after the command to be used in the `args` argument
     """
-    custom_reward_id:str=None
-    registered:ClassVar[dict[str,BotCustomReward]]=None
+    custom_reward_id:str | None = None
+    registered:ClassVar[MutableMapping[str, BotCustomReward]]={}
 
     @classmethod
     def register(
             cls,custom_reward_id:str,
             *,
             args:bool=False
-    ):
+    ) -> Callable[[TBMCCallback], None]:
         """Registers the function to the class"""
-        # make sure the register exists
-        if cls.registered is None:
-            cls.registered = {}
-
         # make sure we don't overwrite an already defined command with the same name
         if custom_reward_id in cls.registered:
             raise ValueError(f"A BotCustomReward with the custom_reward_id of '{custom_reward_id}' already exists")
@@ -55,7 +54,7 @@ class BotCustomReward(BotMethodCallback):
         #   Doesn't behave like a regular decorator because we aren't storing a "wrapper" which handles args and kwargs
         #   Args and kwargs of the function are handled by the handle_chat_message function
         #   It is expected that the function is located within the defined TwitchBot of the application
-        def decorator(fnc):
+        def decorator(fnc: TBMCCallback) -> None:
             cls.registered[custom_reward_id] = cls(
                 custom_reward_id=custom_reward_id,
                 callback=fnc,

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_first_time_chatter.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_first_time_chatter.py
@@ -3,13 +3,16 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
+
 from dataclasses import dataclass
+from collections.abc import Callable
 from typing import ClassVar
 
 # Custom Library
 
 # Custom Packages
 from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import BotMethodCallback
+from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import TBMCCallback
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
@@ -32,14 +35,14 @@ class BotFirstTimeChatter(BotMethodCallback):
     - channel : list of TwitchChannel values which defines on which channels this command should be enabled.
         If left unassigned it will work on all channels the bot is joined on
     """
-    registered: ClassVar[BotFirstTimeChatter] = None
+    registered: ClassVar[BotFirstTimeChatter | None] = None
 
     @classmethod
     def register(
             cls,
             *,
             args:bool=False
-    ):
+    ) -> Callable[[TBMCCallback], None]:
         """Registers the function to the class"""
         # Only allow one registered command for this type
         if cls.registered is not None:
@@ -49,7 +52,7 @@ class BotFirstTimeChatter(BotMethodCallback):
         #   Doesn't behave like a regular decorator because we aren't storing a "wrapper" which handles args and kwargs
         #   Args and kwargs of the function are handled by the handle_chat_message function
         #   It is expected that the function is located within the defined TwitchBot of the application
-        def decorator(fnc):
+        def decorator(fnc: TBMCCallback) -> None:
             cls.registered = cls(
                 callback=fnc,
                 args=args

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_mentioned.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_mentioned.py
@@ -4,6 +4,7 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass
+from collections.abc import Callable
 from typing import ClassVar
 import datetime
 
@@ -11,6 +12,7 @@ import datetime
 
 # Custom Packages
 from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.rate_limit import BotMethodRateLimit
+from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import TBMCCallback
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
@@ -33,14 +35,14 @@ class BotMentioned(BotMethodRateLimit):
     - channel : list of TwitchChannel values which defines on which channels this command should be enabled.
         If left unassigned it will work on all channels the bot is joined on
     """
-    registered:ClassVar[BotMentioned]=None
+    registered:ClassVar[BotMentioned | None]=None
 
     @classmethod
     def register(
             cls,
             *,
-            rate_limit:datetime.timedelta=None,args:bool=False
-    ):
+            rate_limit:datetime.timedelta | None = None,args:bool=False
+    ) -> Callable[[TBMCCallback], None]:
         """Registers the function to the class"""
         # Only allow one registered command for this type
         if cls.registered is not None:
@@ -50,7 +52,7 @@ class BotMentioned(BotMethodRateLimit):
         #   Doesn't behave like a regular decorator because we aren't storing a "wrapper" which handles args and kwargs
         #   Args and kwargs of the function are handled by the handle_chat_message function
         #   It is expected that the function is located within the defined TwitchBot of the application
-        def decorator(fnc):
+        def decorator(fnc: TBMCCallback) -> None:
             cls.registered = cls(
                 callback=fnc,
                 rate_limit=rate_limit,

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_mentioned_start.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_mentioned_start.py
@@ -4,6 +4,7 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass
+from collections.abc import Callable
 from typing import ClassVar
 import datetime
 
@@ -11,6 +12,7 @@ import datetime
 
 # Custom Packages
 from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.rate_limit import BotMethodRateLimit
+from AthenaTwitchBot.models.twitch_bot.bot_methods.bot_method_inheritance.callback import TBMCCallback
 
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
@@ -33,14 +35,14 @@ class BotMentionedStart(BotMethodRateLimit):
     - channel : list of TwitchChannel values which defines on which channels this command should be enabled.
         If left unassigned it will work on all channels the bot is joined on
     """
-    registered:ClassVar[BotMentionedStart]=None
+    registered:ClassVar[BotMentionedStart | None]=None
 
     @classmethod
     def register(
             cls,
             *,
-            rate_limit:datetime.timedelta=None,args:bool=False
-    ):
+            rate_limit:datetime.timedelta | None = None,args:bool=False
+    ) -> Callable[[TBMCCallback], None]:
         """Registers the function to the class"""
         # make sure the register exists
         if cls.registered is not None:
@@ -50,7 +52,7 @@ class BotMentionedStart(BotMethodRateLimit):
         #   Doesn't behave like a regular decorator because we aren't storing a "wrapper" which handles args and kwargs
         #   Args and kwargs of the function are handled by the handle_chat_message function
         #   It is expected that the function is located within the defined TwitchBot of the application
-        def decorator(fnc):
+        def decorator(fnc: TBMCCallback) -> None:
             cls.registered = cls(
                 callback=fnc,
                 rate_limit=rate_limit,

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_method_inheritance/callback.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_method_inheritance/callback.py
@@ -4,7 +4,10 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Callable
+from collections.abc import Callable
+from collections.abc import Awaitable
+from typing import Any
+from typing import Protocol
 
 # Custom Library
 
@@ -15,9 +18,17 @@ from AthenaTwitchBot.models.twitch_bot.message_context import MessageContext
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
 # ----------------------------------------------------------------------------------------------------------------------
+#TODO hard to find types that nicely fit, further investigation needed
+class TBMCCallback(Protocol):
+    def __call__(self, *args: Any, callback_self: TwitchBot, context: MessageContext, **kwargs: Any) -> Awaitable[Any]: ...
+
+
 @dataclass(slots=True)
 class BotMethodCallback:
-    callback:Callable=None
-    args:bool=None
-    async def __call__(self, *args, callback_self:TwitchBot, context:MessageContext, **kwargs):
+    callback: TBMCCallback | None = None
+    args:bool=False
+
+    async def __call__(self, *args: Any, callback_self:TwitchBot, context:MessageContext, **kwargs: Any) -> Any:
+        if self.callback is None:
+            raise ValueError("callback can't be `None`")
         return await self.callback(*args,self=callback_self,context=context,**kwargs)

--- a/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_method_inheritance/rate_limit.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/bot_methods/bot_method_inheritance/rate_limit.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 from dataclasses import dataclass,field
 import datetime
+from typing import Any
 
 # Custom Library
 
@@ -18,17 +19,19 @@ from AthenaTwitchBot.models.twitch_bot.message_context import MessageContext
 # ----------------------------------------------------------------------------------------------------------------------
 @dataclass(slots=True)
 class BotMethodRateLimit(BotMethodCallback):
-    rate_limit:datetime.timedelta=None
+    rate_limit:datetime.timedelta | None = None
     rate_limit_old_time:datetime.datetime=field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # if there is a rate limit in placer
         #   make the command available at the bot start, which is done by subtracting the time delta from the
         #   current time, which places the "virtually last call to the command" far enough away in the past
         if self.rate_limit:
             self.rate_limit_old_time = datetime.datetime.now()-self.rate_limit
 
-    async def __call__(self, *args, callback_self:TwitchBot, context:MessageContext, **kwargs):
+    async def __call__(self, *args: Any, callback_self:TwitchBot, context:MessageContext, **kwargs: Any) -> Any:
+        if self.callback is None:
+            raise ValueError("callback can't be `None`")
         # rate limiter
         #   set here as the rate limit can be applied to all commands and makes the match case statement much more easy
         if self.rate_limit:

--- a/src/AthenaTwitchBot/models/twitch_bot/logic_output.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/logic_output.py
@@ -4,6 +4,8 @@
 # General Packages
 from __future__ import annotations
 
+from collections.abc import MutableMapping
+
 # Custom Library
 
 # Custom Packages
@@ -16,10 +18,10 @@ from AthenaTwitchBot.models.twitch_bot.outputs.output_console import OutputConso
 # - Code -
 # ----------------------------------------------------------------------------------------------------------------------
 class LogicOutput:
-    mapping:dict[OutputTypes:Output]
+    mapping: MutableMapping[OutputTypes,Output]
     __slots__ = ("mapping",)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.mapping = {
             self.types.twitch:OutputTwitch(),
             self.types.console:OutputConsole()
@@ -29,10 +31,10 @@ class LogicOutput:
     def types(self) -> type[OutputTypes]:
         return OutputTypes
 
-    def __getitem__(self, item:OutputTypes):
+    def __getitem__(self, item:OutputTypes) -> Output:
         return self.mapping[item]
 
-    def register_mapping(self, item:OutputTypes, output:Output):
+    def register_mapping(self, item:OutputTypes, output:Output) -> None:
         if item in self.mapping:
             raise ValueError(f"No same item ({item.value}) can be used in the output system")
         # noinspection PyTypeChecker

--- a/src/AthenaTwitchBot/models/twitch_bot/message_context.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/message_context.py
@@ -3,7 +3,7 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 # Custom Library
 
@@ -18,18 +18,18 @@ from AthenaTwitchBot.models.twitch_user import TwitchUser
 # ----------------------------------------------------------------------------------------------------------------------
 @dataclass(kw_only=True, slots=True)
 class MessageContext:
-    raw_input:bytearray=None
-    raw_input_decoded:str=None
-    raw_input_decoded_split:list[str]=None
-    chat_message:tuple[str]=None
+    raw_input:bytes | None=None
+    raw_input_decoded:str | None=None
+    raw_input_decoded_split:list[str] = field(default_factory=list)
+    chat_message:tuple[str, ...] = ()
     flag:MessageFlags=MessageFlags.undefined
-    output:str=None
-    _tags:MessageTags=None
-    _channel:TwitchChannel=None
-    _user:TwitchUser=None
+    output:str | None=None
+    _tags:MessageTags = MessageTags()
+    _channel:TwitchChannel=TwitchChannel('')
+    _user:TwitchUser=TwitchUser('')
     rate_limited:bool=False
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.raw_input is not None:
             self.raw_input_decoded = self.raw_input.decode("utf_8")
             self.raw_input_decoded_split = self.raw_input_decoded.split(" ")
@@ -38,36 +38,36 @@ class MessageContext:
     # - Properties -
     # ------------------------------------------------------------------------------------------------------------------
     @property
-    def tags(self):
+    def tags(self) -> MessageTags:
         return self._tags
     @tags.setter
-    def tags(self, value:str):
+    def tags(self, value:str) -> None:
         if value is not None:
             self._tags = MessageTags.new_from_tags_str(value)
 
     # ------------------------------------------------------------------------------------------------------------------
     @property
-    def channel(self):
+    def channel(self) -> TwitchChannel:
         return self._channel
     @channel.setter
-    def channel(self, value:str):
+    def channel(self, value:str) -> None:
         self._channel = TwitchChannel(value)
     # ------------------------------------------------------------------------------------------------------------------
     @property
-    def user(self):
+    def user(self) -> TwitchUser:
         return self._user
     @user.setter
-    def user(self, value:str):
+    def user(self, value:str) -> None:
         self._user = TwitchUser(value)
 
     # ------------------------------------------------------------------------------------------------------------------
     # - Special methods -
     # ------------------------------------------------------------------------------------------------------------------
-    def write(self,output: str):
+    def write(self,output: str) -> None:
         self.output = output
         self.flag = MessageFlags.write
 
-    def reply(self, output: str):
+    def reply(self, output: str) -> None:
         if self.raw_input is None: # which means the context was probably created in a task or something like it
             raise ValueError(
                 "This context was not created as a reponse to a chat message and therefor can't reply to anything"

--- a/src/AthenaTwitchBot/models/twitch_bot/message_tags.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/message_tags.py
@@ -4,8 +4,11 @@
 # General Packages
 from __future__ import annotations
 from dataclasses import dataclass, field
+from collections.abc import Callable
+from collections.abc import MutableMapping
+from collections.abc import Mapping
 from typing import Any
-from typing import Callable
+from typing import Self
 
 # Custom Library
 from AthenaLib.data.text import NOTHING
@@ -22,7 +25,7 @@ from AthenaColor import ForeNest, HEX
 #   The key is the string stored in the irc but because it used characters that can't be used as class attributes names,
 #       the key has to be mapped to the corresponding attr name and any conversion that needs to be done
 
-MESSAGE_TAG_MAPPING:dict[str:tuple[str,Callable]] = {
+MESSAGE_TAG_MAPPING: Mapping[str, tuple[str, Callable[[Any], Any]]] = {
     "badge-info":                   ("badge_info",                  (_return_as_is := lambda value: value)),
     "badges":                       ("badges",                      _return_as_is),
     "client-nonce":                 ("client_nonce",                _return_as_is),
@@ -88,13 +91,14 @@ class MessageTags:
     vip:bool=False
 
     @classmethod
-    def new_from_tags_str(cls, tags_str:str) -> MessageTags:
-        attr_value:dict[str:Any] = {}
+    def new_from_tags_str(cls, tags_str:str) -> Self:  # type: ignore [valid-type]
+      # issue with type checkers, should be somthing like: MutableMapping[str, str | HEX | bool]
+        attr_value: MutableMapping[str, Any] = {}
         for tag_value in tags_str.split(";"):
             tag,value = tag_value.split("=")
             try:
                 attr_name, callback = MESSAGE_TAG_MAPPING[tag.replace("@", "")]
-                attr_value[attr_name] = callback(value=value)
+                attr_value[attr_name] = callback(value)
             except KeyError:
                 # don't make this crash the bot !
                 print(ForeNest.Maroon(f"{tag} not found in mapping"))

--- a/src/AthenaTwitchBot/models/twitch_bot/outputs/output.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/outputs/output.py
@@ -3,7 +3,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # General Packages
 from __future__ import annotations
+
 import abc
+import asyncio
+from typing import Any
+from typing import overload
 
 # Custom Library
 
@@ -17,7 +21,7 @@ class Output(abc.ABC):
     """
     An abstract class to define which structure the output classes should use
     """
-    async def output(self, context:MessageContext,**kwargs):
+    async def output(self, context:MessageContext, *, transport: asyncio.BaseTransport | None) -> None:
         """
         Output a context the correct end state
         """

--- a/src/AthenaTwitchBot/models/twitch_bot/outputs/output_console.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/outputs/output_console.py
@@ -4,6 +4,8 @@
 # General Packages
 from __future__ import annotations
 
+import asyncio
+from typing import Any
 # Custom Library
 
 # Custom Packages
@@ -16,8 +18,6 @@ from AthenaTwitchBot.models.twitch_bot.message_context import MessageContext
 # ----------------------------------------------------------------------------------------------------------------------
 class OutputConsole(Output):
     # noinspection PyMethodOverriding
-    async def output(self, context:MessageContext,**_):
-        if context.flag == MessageFlags.no_output:
-            return
-        elif context.raw_input_decoded is not None:
+    async def output(self, context:MessageContext, transport: asyncio.BaseTransport | None) -> None:
+        if context.raw_input_decoded is not None:
             print(context.raw_input_decoded)

--- a/src/AthenaTwitchBot/models/twitch_bot/outputs/output_twitch.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/outputs/output_twitch.py
@@ -61,7 +61,7 @@ class OutputTwitch(Output):
     }
 
     # noinspection PyMethodOverriding
-    async def output(self, context:MessageContext,*,transport:asyncio.Transport):
+    async def output(self, context:MessageContext,* ,transport:asyncio.BaseTransport | None = None) -> None:
         # if no output has been defined, just exit here
         if context.output is None:
             return

--- a/src/AthenaTwitchBot/models/twitch_bot/twitch_bot.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/twitch_bot.py
@@ -33,7 +33,7 @@ class TwitchBot:
     twitch_capability_membership:bool=False
     twitch_capability_tags:bool=True # only one that has the default set to true, is required to make reply's work
 
-    client_id:str=None # needed for the twitch API
+    client_id:str | None=None # needed for the twitch API
 
     #post init
     nickname_at:str=field(init=False)
@@ -41,7 +41,7 @@ class TwitchBot:
     nickname_irc:str=field(init=False)
     command_prefix_irc:str=field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.nickname_at = f"@{self.nickname}"
         self.nickname_at_irc = f":@{self.nickname}"
         self.nickname_irc = f":{self.nickname}"

--- a/src/AthenaTwitchBot/models/twitch_bot/twitch_bot_protocol.py
+++ b/src/AthenaTwitchBot/models/twitch_bot/twitch_bot_protocol.py
@@ -13,14 +13,14 @@ from AthenaTwitchBot.models.twitch_bot.line_handler import LineHandler
 # ----------------------------------------------------------------------------------------------------------------------
 # - Code -
 # ----------------------------------------------------------------------------------------------------------------------
-class TwitchBotProtocol(asyncio.Protocol):
+class TwitchBotProtocol(asyncio.BaseProtocol):
     transport: asyncio.transports.BaseTransport
     __slots__ = ("transport",)
 
     # ------------------------------------------------------------------------------------------------------------------
     # - asyncio.Protocol methods-
     # ------------------------------------------------------------------------------------------------------------------
-    def data_received(self, data: bytearray) -> None:
+    def data_received(self, data: bytes) -> None:
         for line in data.split(b"\r\n"):
             if line:
                 asyncio.create_task(LineHandler.handle_line(line))

--- a/src/AthenaTwitchBot/models/twitch_channel.py
+++ b/src/AthenaTwitchBot/models/twitch_channel.py
@@ -22,7 +22,7 @@ class TwitchChannel:
     """
     name:str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.name[0] != "#":
             self.name = f"#{self.name}"
 

--- a/src/AthenaTwitchBot/models/twitch_user.py
+++ b/src/AthenaTwitchBot/models/twitch_user.py
@@ -22,7 +22,7 @@ class TwitchUser:
     """
     name:str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # :billy_ikanda!billy_ikanda@billy_ikanda.tmi.twitch.tv
         self.name = self.name.split("!")[0][1:]
 


### PR DESCRIPTION
# Changes
## General
- Added types
- Corrected types

## Dependencies
### Version pin
Pinned `AthenaLib` between version `1.1.0` and `2.0.0`. 
These seem to be the only versions that include the `HTTP` module, that `AthenaTwitchLib` needs

### Detection of serious incompatibility issue 
Take a look at #38

## Typing TODOs
- The `Mapping[str, Any]` or `MutableMapping[str, Any]` in `twitch_api.py` could be more specific.
- Need to take a closer look at the `_request` method in the same file, once because of the serious is»
between `AthenaLib` and `AthenaTwitchLib`, second because of the additional (now commented out) parame»
`method` in the `RequestCallback` type
- `TRequest = Mapping[Any, Any]` definitely should be more specific, but i wasn't able to further narrow it down correctly
- Eventually there are more places that can be considered to use `typing.Self`

## Logic changes
- `launcher.py`: removed `api` property and switched all occurences to `_api` (pretty much the same for `_bot`, but for that a property didn't exist, made it easier)
- `twitch_api.py`: 
    - normalized `_request` to uniform return value, raising a few new error (chains)
- many files: changed `bool` default values from `None` to `False`
- many files: changed some function calls, as some didn't expected keyword arguments, but keyword arguments were given
- many files: added `assert` statements to make sure globals are not `None`

(*Allow edits by maintainers* is intentionally disabled, please consider a discussion instead)

Converted to draft as forgot `py.typed` and need to revert version pinning, as it only got moved, not removed.